### PR TITLE
If a file open in linuxspi_gpio_op_wr fails, retry after a delay

### DIFF
--- a/linuxspi.c
+++ b/linuxspi.c
@@ -180,6 +180,14 @@ static int linuxspi_gpio_op_wr(PROGRAMMER* pgm, LINUXSPI_GPIO_OP op, int gpio, c
     
     FILE* f = fopen(fn, "w");
     
+    int fopen_retries = 0;
+    while (!f && fopen_retries < 100)
+    {
+        usleep(20000);
+        f = fopen(fn, "w");
+        fopen_retries++;
+    }
+
     if (!f)
     {
         fprintf(stderr, "%s: linuxspi_gpio_op_wr(): Unable to open file %s", progname, fn);


### PR DESCRIPTION
Setting the reset pin direction immediately after export doesn't allow enough time for the udev rule to give access rights to the gpio user group. This causes avrdude commands run as non-root to fail:
```
avrdude: linuxspi_gpio_op_wr(): Unable to open file /sys/class/gpio/gpio25/direction
```

This change has been accepted by the author of the linuxspi programmer code:
https://github.com/kcuzner/avrdude/pull/17