### PR TITLE
Added ATtiny87 and 167 specifications   # But this is a dead repository :-(

### DIFF
--- a/avrdude.conf.in
+++ b/avrdude.conf.in
@@ -15054,6 +15054,385 @@ part
 ;
 
 #------------------------------------------------------------
+# ATtiny87
+#------------------------------------------------------------
+
+# Changes against ATtiny167 (beside IDs)
+#    memory "flash"
+#        size            = 8192;
+#        num_pages       = 64;
+
+part
+     id            = "t87";
+     desc          = "ATtiny87";
+     has_debugwire = yes;
+     flash_instr   = 0xB6, 0x01, 0x11;
+     eeprom_instr  = 0xBD, 0xF2, 0xBD, 0xE1, 0xBB, 0xCF, 0xB4,
+               0x00, 0xBE, 0x01, 0xB6, 0x01, 0xBC, 0x00, 0xBB,
+               0xBF, 0x99, 0xF9, 0xBB, 0xAF;
+## no STK500 devcode in XML file, use the ATtiny45 one
+     stk500_devcode   = 0x14;
+##  avr910_devcode   = ?;
+##  Try the AT90S2313 devcode:
+     avr910_devcode   = 0x20;
+     signature        = 0x1e 0x93 0x87;
+     reset            = io;
+     chip_erase_delay = 1000;
+
+     pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                        "x x x x  x x x x    x x x x  x x x x";
+
+     chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+                        "x x x x  x x x x    x x x x  x x x x";
+
+    timeout     = 200;
+    stabdelay       = 100;
+    cmdexedelay     = 25;
+    synchloops      = 32;
+    bytedelay       = 0;
+    pollindex       = 3;
+    pollvalue       = 0x53;
+    predelay        = 1;
+    postdelay       = 1;
+    pollmethod      = 0;
+
+    pp_controlstack     =
+        0x0E, 0x1E, 0x0E, 0x1E, 0x2E, 0x3E, 0x2E, 0x3E,
+        0x4E, 0x5E, 0x4E, 0x5E, 0x6E, 0x7E, 0x6E, 0x7E,
+        0x06, 0x16, 0x46, 0x56, 0x0A, 0x1A, 0x4A, 0x5A,
+        0x1E, 0x7C, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 5;
+    togglevtg           = 1;
+    poweroffdelay       = 20;
+    resetdelayms        = 1;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    chiperasepulsewidth = 0;
+    chiperasepolltimeout = 10;
+    programfusepulsewidth = 0;
+    programfusepolltimeout = 5;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 5;
+
+    idr                 = 0x00;
+    spmcr               = 0x57;
+    allowfullpagebitstream = no;
+
+     memory "eeprom"
+         size            = 512;
+        paged           = no;
+        page_size       = 4;
+         min_write_delay = 4000;
+         max_write_delay = 4500;
+         readback_p1     = 0xff;
+         readback_p2     = 0xff;
+         read            = "1  0  1  0   0  0  0  0    0 0 x x  x x x a8",
+                           "a7 a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
+
+         write           = "1  1  0  0   0  0  0  0    0 0 x x  x x x a8",
+                           "a8 a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
+
+  loadpage_lo   = "  1   1   0   0      0   0   0   1",
+        "  0   0   0   0      0   0   0   0",
+        "  0   0   0   0      0   0  a1  a0",
+        "  i   i   i   i      i   i   i   i";
+
+  writepage = "  1   1   0   0      0   0   1   0",
+        "  0   0   x   x      x   x   x   x",
+        "  0   0  a5  a4     a3  a2   0   0",
+        "  x   x   x   x      x   x   x   x";
+
+  mode      = 0x41;
+  delay     = 10;
+  blocksize = 4;
+  readsize  = 256;
+       ;
+     memory "flash"
+         paged           = yes;
+         size            = 8192;
+         page_size       = 128;
+         num_pages       = 64;
+         min_write_delay = 4500;
+         max_write_delay = 4500;
+         readback_p1     = 0xff;
+         readback_p2     = 0xff;
+         read_lo         = "  0   0   1   0    0   0   0   0",
+                           "  0   0   0  a12  a11 a10  a9  a8",
+                           " a7  a6  a5  a4   a3  a2   a1  a0",
+                           "  o   o   o   o    o   o   o   o";
+
+         read_hi         = "  0   0   1   0    1   0   0   0",
+                           "  0   0   0  a12  a11 a10  a9  a8",
+                           " a7  a6  a5  a4   a3  a2   a1  a0",
+                           "  o   o   o   o    o   o   o   o";
+
+         loadpage_lo     = "  0   1   0   0    0   0   0   0",
+                           "  0   0   0   x    x   x   x   x",
+                           "  x   x  a5  a4   a3  a2  a1  a0",
+                           "  i   i   i   i    i   i   i   i";
+
+         loadpage_hi     = "  0   1   0   0    1   0   0   0",
+                           "  0   0   0   x    x   x   x   x",
+                           "  x   x  a5  a4   a3  a2  a1  a0",
+                           "  i   i   i   i    i   i   i   i";
+
+         writepage       = "  0  1  0  0   1   1   0  0",
+                           "  0  0  0  0  a11 a10 a9 a8",
+                           " a7 a6 a5  x   x  x  x  x",
+                           "  x  x  x  x   x  x  x  x";
+
+  mode      = 0x41;
+  delay     = 10;
+  blocksize = 64;
+  readsize  = 256;
+       ;
+#   ATtiny87 has Signature Bytes: 0x1E 0x93 0x87.
+     memory "signature"
+         size            = 3;
+         read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
+                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+       ;
+
+     memory "lock"
+         size            = 1;
+         write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
+                           "x x x x  x x x x  x x x x  x x i i";
+         read            = "0 1 0 1  1 0 0 0  0 0 0 0  0 0 0 0",
+                           "0 0 0 0  0 0 0 0  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+       ;
+
+     memory "lfuse"
+         size            = 1;
+         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
+                           "x x x x  x x x x  i i i i  i i i i";
+
+         read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
+                           "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+       ;
+
+     memory "hfuse"
+         size            = 1;
+         write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
+                           "x x x x  x x x x  i i i i  i i i i";
+
+         read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
+                           "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+       ;
+
+     memory "efuse"
+         size            = 1;
+         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
+                           "x x x x  x x x x  x x x x  x x x i";
+
+         read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
+                           "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+     ;
+
+     memory "calibration"
+         size            = 1;
+         read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
+                           "0  0  0  0   0  0  0  a0   o o o o  o o o o";
+     ;
+  ;
+
+#------------------------------------------------------------
+# ATtiny167
+#------------------------------------------------------------
+
+part
+     id            = "t167";
+     desc          = "ATtiny167";
+     has_debugwire = yes;
+     flash_instr   = 0xB6, 0x01, 0x11;
+     eeprom_instr  = 0xBD, 0xF2, 0xBD, 0xE1, 0xBB, 0xCF, 0xB4,
+               0x00, 0xBE, 0x01, 0xB6, 0x01, 0xBC, 0x00, 0xBB,
+               0xBF, 0x99, 0xF9, 0xBB, 0xAF;
+## no STK500 devcode in XML file, use the ATtiny45 one
+     stk500_devcode   = 0x14;
+##  avr910_devcode   = ?;
+##  Try the AT90S2313 devcode:
+     avr910_devcode   = 0x20;
+     signature        = 0x1e 0x94 0x87;
+     reset            = io;
+     chip_erase_delay = 1000;
+
+     pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                        "x x x x  x x x x    x x x x  x x x x";
+
+     chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+                        "x x x x  x x x x    x x x x  x x x x";
+
+    timeout     = 200;
+    stabdelay       = 100;
+    cmdexedelay     = 25;
+    synchloops      = 32;
+    bytedelay       = 0;
+    pollindex       = 3;
+    pollvalue       = 0x53;
+    predelay        = 1;
+    postdelay       = 1;
+    pollmethod      = 0;
+
+    pp_controlstack     =
+        0x0E, 0x1E, 0x0E, 0x1E, 0x2E, 0x3E, 0x2E, 0x3E,
+        0x4E, 0x5E, 0x4E, 0x5E, 0x6E, 0x7E, 0x6E, 0x7E,
+        0x06, 0x16, 0x46, 0x56, 0x0A, 0x1A, 0x4A, 0x5A,
+        0x1E, 0x7C, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 5;
+    togglevtg           = 1;
+    poweroffdelay       = 20;
+    resetdelayms        = 1;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    chiperasepulsewidth = 0;
+    chiperasepolltimeout = 10;
+    programfusepulsewidth = 0;
+    programfusepolltimeout = 5;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 5;
+
+    idr                 = 0x00;
+    spmcr               = 0x57;
+    allowfullpagebitstream = no;
+
+     memory "eeprom"
+         size            = 512;
+        paged           = no;
+        page_size       = 4;
+         min_write_delay = 4000;
+         max_write_delay = 4500;
+         readback_p1     = 0xff;
+         readback_p2     = 0xff;
+         read            = "1  0  1  0   0  0  0  0    0 0 x x  x x x a8",
+                           "a7 a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
+
+         write           = "1  1  0  0   0  0  0  0    0 0 x x  x x x a8",
+                           "a8 a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
+
+  loadpage_lo   = "  1   1   0   0      0   0   0   1",
+        "  0   0   0   0      0   0   0   0",
+        "  0   0   0   0      0   0  a1  a0",
+        "  i   i   i   i      i   i   i   i";
+
+  writepage = "  1   1   0   0      0   0   1   0",
+        "  0   0   x   x      x   x   x   x",
+        "  0   0  a5  a4     a3  a2   0   0",
+        "  x   x   x   x      x   x   x   x";
+
+  mode      = 0x41;
+  delay     = 10;
+  blocksize = 4;
+  readsize  = 256;
+       ;
+     memory "flash"
+         paged           = yes;
+         size            = 16384;
+         page_size       = 128;
+         num_pages       = 128;
+         min_write_delay = 4500;
+         max_write_delay = 4500;
+         readback_p1     = 0xff;
+         readback_p2     = 0xff;
+         read_lo         = "  0   0   1   0    0   0   0   0",
+                           "  0   0   0  a12  a11 a10  a9  a8",
+                           " a7  a6  a5  a4   a3  a2   a1  a0",
+                           "  o   o   o   o    o   o   o   o";
+
+         read_hi         = "  0   0   1   0    1   0   0   0",
+                           "  0   0   0  a12  a11 a10  a9  a8",
+                           " a7  a6  a5  a4   a3  a2   a1  a0",
+                           "  o   o   o   o    o   o   o   o";
+
+         loadpage_lo     = "  0   1   0   0    0   0   0   0",
+                           "  0   0   0   x    x   x   x   x",
+                           "  x   x  a5  a4   a3  a2  a1  a0",
+                           "  i   i   i   i    i   i   i   i";
+
+         loadpage_hi     = "  0   1   0   0    1   0   0   0",
+                           "  0   0   0   x    x   x   x   x",
+                           "  x   x  a5  a4   a3  a2  a1  a0",
+                           "  i   i   i   i    i   i   i   i";
+
+         writepage       = "  0  1  0  0   1   1   0  0",
+                           "  0  0  0  0  a11 a10 a9 a8",
+                           " a7 a6 a5  x   x  x  x  x",
+                           "  x  x  x  x   x  x  x  x";
+
+  mode      = 0x41;
+  delay     = 10;
+  blocksize = 64;
+  readsize  = 256;
+       ;
+#   ATtiny167 has Signature Bytes: 0x1E 0x94 0x87.
+     memory "signature"
+         size            = 3;
+         read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
+                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+       ;
+
+     memory "lock"
+         size            = 1;
+         write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
+                           "x x x x  x x x x  x x x x  x x i i";
+         read            = "0 1 0 1  1 0 0 0  0 0 0 0  0 0 0 0",
+                           "0 0 0 0  0 0 0 0  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+       ;
+
+     memory "lfuse"
+         size            = 1;
+         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
+                           "x x x x  x x x x  i i i i  i i i i";
+
+         read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
+                           "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+       ;
+
+     memory "hfuse"
+         size            = 1;
+         write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
+                           "x x x x  x x x x  i i i i  i i i i";
+
+         read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
+                           "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+       ;
+
+     memory "efuse"
+         size            = 1;
+         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
+                           "x x x x  x x x x  x x x x  x x x i";
+
+         read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
+                           "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+     ;
+
+     memory "calibration"
+         size            = 1;
+         read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
+                           "0  0  0  0   0  0  0  a0   o o o o  o o o o";
+     ;
+  ;
+  
+#------------------------------------------------------------
 # Common values for reduced core tinys (4/5/9/10/20/40)
 #------------------------------------------------------------
 


### PR DESCRIPTION
The ATtiny167 specs are well tested by me bu using it around 10 times using Arduino as ISP without any problems!
The 87 spcecs only have differences at the id, desc, signature, size, num_pages fields as expected. These differences were checked against the datasheet.

It would be great to have it in the official Arduino release. Until now I must maintain a special version [here](https://github.com/ArminJo/micronucleus-firmware#if-you-want-to-burn-the-bootloader-to-an-attiny87-or-attiny167-with-avrdude-you-must-use-the-avrdudeconfig-file-in-windows_exe-where-attiny87-and-attiny167-specifications-are-added).